### PR TITLE
alertmanagerKube: add readinessProbe for the Alertmanager container

### DIFF
--- a/alertmanagerKube/main.libsonnet
+++ b/alertmanagerKube/main.libsonnet
@@ -81,7 +81,10 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       + container.resources.withRequests({
         cpu: '10m',
         memory: '40Mi',
-      }),
+      })
+      + container.readinessProbe.httpGet.withPath('%s-/ready' % self.path)
+      + container.readinessProbe.httpGet.withPort(port)
+    ,
 
     watch_container::
       container.new('watch', watchImage)


### PR DESCRIPTION
Upstreaming some of the readinessProbe jsonnet code that its being used with Alertmanager.

I initially went for incorporating this in the `new` function, so you don't need to opt-in into using a more robust setup. If we prefer to have this into its own mixin, I can extract it, don't have too much of a strong opinion there.