### PR TITLE
Adding configmap hash to alertmanager

### DIFF
--- a/alertmanagerKube/jsonnetfile.json
+++ b/alertmanagerKube/jsonnetfile.json
@@ -18,6 +18,15 @@
         }
       },
       "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
+          "subdir": "1.30"
+        }
+      },
+      "version": "main"
     }
   ],
   "legacyImports": true

--- a/alertmanagerKube/main.libsonnet
+++ b/alertmanagerKube/main.libsonnet
@@ -1,6 +1,7 @@
 local alertmanagerConfig = import 'github.com/crdsonnet/alertmanager-libsonnet/alertmanagerConfig/main.libsonnet';
 local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet';
 local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+local klib = import "github.com/jsonnet-libs/k8s-libsonnet/1.30/main.libsonnet";
 
 {
   '#'::
@@ -133,7 +134,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       + statefulset.spec.template.spec.securityContext.withFsGroup(2000)
       + statefulset.spec.template.spec.securityContext.withRunAsUser(1000)
       + statefulset.spec.template.spec.securityContext.withRunAsNonRoot(true)
-      + k.util.configVolumeMount(
+      + klib.apps.v1.statefulSet.configMapVolumeMount(
         self.config_map.metadata.name,
         self.config_path,
       )


### PR DESCRIPTION
Addresses https://github.com/crdsonnet/alertmanager-libsonnet/issues/4

Adding a hash to the Statefulset annotation for the mounted configmap so as to no longer require manual reloading of the STS to get config changes.