### PR TITLE
fix(common matchers): accept arrays as well as strings

### DIFF
--- a/alertmanagerConfig/veneer.libsonnet
+++ b/alertmanagerConfig/veneer.libsonnet
@@ -222,27 +222,48 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     local this = self,
 
     '#alert':: d.fn(
-      '`alert` matches an `alertname`.',
-      args=[d.arg('alertname', d.T.string)]
+      '`alert` matches one or more alert names.',
+      args=[d.arg('alertname', d.T.array)]
     ),
-    alert(alertname): fn('alertname=~"' + alertname + '"'),
+    alert(alertname): fn(
+      root.util.matchArrayOrString(
+        'alertname',
+        alertname
+      )
+    ),
 
     '#cluster':: d.fn(
       '`cluster` matches a cluster.',
-      args=[d.arg('cluster', d.T.string)]
+      args=[d.arg('cluster', d.T.array)]
     ),
-    cluster(cluster): fn('cluster="' + cluster + '"'),
+    cluster(cluster): fn(
+      root.util.matchArrayOrString(
+        'cluster',
+        cluster
+      )
+    ),
+
     '#team':: d.fn(
       '`team` matches a team.',
-      args=[d.arg('team', d.T.string)]
+      args=[d.arg('team', d.T.array)]
     ),
-    team(team): fn('team="' + team + '"'),
+    team(team): fn(
+      root.util.matchArrayOrString(
+        'team',
+        team
+      )
+    ),
 
     '#severity':: d.fn(
       '`severity` matches a severity.',
-      args=[d.arg('severity', d.T.string)]
+      args=[d.arg('severity', d.T.array)]
     ),
-    severity(severity): fn('severity=~"' + severity + '"'),
+    severity(severity): fn(
+      root.util.matchArrayOrString(
+        'severity',
+        severity
+      )
+    ),
 
     severityMatcher: {
       '#critical':: d.fn('`critical` matches a critical severity.',),


### PR DESCRIPTION
We have some shorthand functions to add matchers for labels like `alertname`, `cluster` and so on. These are currently typed to only accept strings. The [upstream configuration][config-docs] show that these can accept multiple values when given as a regular expression with alternates.

That's what our existing `matchArrayOrString` helper does. It's just not used here - let's do that. Now the code

```jsonnet
inhibit_rule.sourceMatcher.alert('KubeNodeNotReady')
+ inhibit_rule.targetMatcher.alert(['PromScrapeFlapping', 'PromScrapeFailed'])
+ inhibit_rule.targetMatcher.namespace(['nsone', 'nstwo']
```

Will produce the expected regular expression for the `alertname` label, as it already did for the `namespace` label.

The same argument applies to `cluster`, `team` and `severity`, so we update those here too.

[config-docs]: https://prometheus.io/docs/alerting/latest/configuration/#matcher
